### PR TITLE
Handle fatal error: converted pointer straddles multiple allocations

### DIFF
--- a/buffer/pool.go
+++ b/buffer/pool.go
@@ -68,8 +68,7 @@ func getBuf(size int) []byte {
 				// Get back the array and add length and capability.
 				// Limiting the array to the proper capability will make this
 				// safe.
-				buf := (*[maxArraySize]byte)(v.(unsafe.Pointer))
-				return buf[:0:size]
+				return (*[maxArraySize]byte)(v.(unsafe.Pointer))[:0:size]
 			}
 		}
 	}


### PR DESCRIPTION
When running easyjson with `-race`, we can sometimes see the following fatal error message:

```c

fatal error: checkptr: converted pointer straddles multiple allocations


goroutine 28 [running]:
runtime.throw({0x158bcf3, 0xc0003ee200})
    /usr/local/go/src/runtime/panic.go:1198 +0x71 fp=0xc0001a7148 sp=0xc0001a7118 pc=0x46b111
runtime.checkptrAlignment(0xc000469980, 0xc000194750, 0x200)
    /usr/local/go/src/runtime/checkptr.go:26 +0x6c fp=0xc0001a7168 sp=0xc0001a7148 pc=0x43a16c
github.com/cyralinc/easyjson/buffer.getBuf(0x200)
    /go/pkg/mod/github.com/cyralinc/easyjson@v0.7.11/buffer/pool.go:71 +0xc5 fp=0xc0001a71a0 sp=0xc0001a7168 pc=0x6b7385
github.com/cyralinc/easyjson/buffer.(*Buffer).ensureSpaceSlow(0xc0001d72d0, 0x4a3fe5)
    /go/pkg/mod/github.com/cyralinc/easyjson@v0.7.11/buffer/pool.go:116 +0x2e9 fp=0xc0001a7238 sp=0xc0001a71a0 pc=0x6b77c9
github.com/cyralinc/easyjson/buffer.(*Buffer).EnsureSpace(...)
    /go/pkg/mod/github.com/cyralinc/easyjson@v0.7.11/buffer/pool.go:93
github.com/cyralinc/easyjson/buffer.(*Buffer).appendStringSlow(0xc0001d72d0, {0x155bfc8, 0x12})
    /go/pkg/mod/github.com/cyralinc/easyjson@v0.7.11/buffer/pool.go:160 +0x96 fp=0xc0001a72a0 sp=0xc0001a7238 pc=0x6b80b6
github.com/cyralinc/easyjson/buffer.(*Buffer).AppendString(...)
    /go/pkg/mod/github.com/cyralinc/easyjson@v0.7.11/buffer/pool.go:154
github.com/cyralinc/easyjson/jwriter.(*Writer).String(0xc0001d72b8, {0x155bfc8, 0x12})
    /go/pkg/mod/github.com/cyralinc/easyjson@v0.7.11/jwriter/writer.go:359 +0x1455 fp=0xc0001a7350 sp=0xc0001a72a0 pc=0x6beed5
github.com/cyralinc/activity-log.easyjson32ceb8acEncodeGithubComCyralincActivityLog(0xc0001d72b8, {{0x1553e14, 0xa}, {0x155bfc8, 0x12}, {0x154cdaf, 0x2}, {0x1556faa, 0xd}, 0x1bb})
    /go/pkg/mod/github.com/cyralinc/activity-log@v0.5.1/repository_easyjson.go:71 +0x99 fp=0xc0001a7380 sp=0xc0001a7350 pc=0x8e3699
github.com/cyralinc/activity-log.Repository.MarshalEasyJSON(...)
    /go/pkg/mod/github.com/cyralinc/activity-log@v0.5.1/repository_easyjson.go:100
github.com/cyralinc/activity-log.easyjsonFe0f5c3cEncodeGithubComCyralincActivityLog(_, {{0xc0005811c0, 0x1c}, {0xc000044c00, 0x27}, 0x1700d16ca27e452b, {0xc000523c80, 0x1, 0x1}, {0x1792c10, ...}, ...})
    /go/pkg/mod/github.com/cyralinc/activity-log@v0.5.1/activity_log_easyjson.go:215 +0x26c fp=0xc0001a7648 sp=0xc0001a7380 pc=0x8dcc2c
github.com/cyralinc/activity-log.ActivityLogImpl.MarshalEasyJSON(...)
    /go/pkg/mod/github.com/cyralinc/activity-log@v0.5.1/activity_log_easyjson.go:316
github.com/cyralinc/activity-log.(*ActivityLogImpl).MarshalEasyJSON(0xc000101400, 0x179c750)
    <autogenerated>:1 +0xec fp=0xc0001a79c0 sp=0xc0001a7648 pc=0x8ee0cc
github.com/cyralinc/activity-log/log-manager.(*Manager).Log(0xc0001d7290, {0x179c750, 0xc000101400})
    /go/pkg/mod/github.com/cyralinc/activity-log@v0.5.1/log-manager/log-manager.go:156 +0xc3 fp=0xc0001a7a48 sp=0xc0001a79c0 pc=0x1155483
github.com/cyralinc/s3-wire/internal/s3/analyzer/qp.(*StatefulS3Analyzer).Log(...)
    /cyralinc/s3-wire/internal/s3/analyzer/qp/query_processor.go:262
github.com/cyralinc/s3-wire/internal/s3/analyzer/qp.(*StatefulS3Analyzer).AnalyzeOneResponse(0xc0001d6510, 0xc000101400, 0xc0001b8008)
    /cyralinc/s3-wire/internal/s3/analyzer/qp/query_processor.go:505 +0x13a5 fp=0xc0001a7ca8 sp=0xc0001a7a48 pc=0x12f4c05
github.com/cyralinc/s3-wire/internal/s3/analyzer/qp.TestStatefulS3Analyzer_AnalyzeOneResponse(0x0)
    /cyralinc/s3-wire/internal/s3/analyzer/qp/query_processor_test.go:175 +0x8dd fp=0xc0001a7e98 sp=0xc0001a7ca8 pc=0x12fa61d
testing.tRunner(0xc000582d00, 0x15a4cb8)
    /usr/local/go/src/testing/testing.go:1259 +0x230 fp=0xc0001a7fb0 sp=0xc0001a7e98 pc=0x59b510
testing.(*T).Run·dwrap·21()
    /usr/local/go/src/testing/testing.go:1306 +0x48 fp=0xc0001a7fe0 sp=0xc0001a7fb0 pc=0x59caa8
runtime.goexit()
    /usr/local/go/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc0001a7fe8 sp=0xc0001a7fe0 pc=0x4a1221
created by testing.(*T).Run
    /usr/local/go/src/testing/testing.go:1306 +0x727
```

This is not reproducible without the `-race` flag. There are two possible solutions, which are either to
do the refactoring present in this PR or use this alternative instead:

```go
return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
		Data: uintptr(v.(unsafe.Pointer)),
		Len:  0,
		Cap:  size,
	}))
```

In our tests, both solutions (proposed by @fziglio ) worked but we chose the minor refactoring, as it is simpler and the usage of `uintptr` turns the pointer into an integer, which doesn't sum up to the references to that address, meaning `v` could be garbage collected while we were still "using" that.
